### PR TITLE
Fix stale leader response by supporting OnNewLeader

### DIFF
--- a/election/Godeps/Godeps.json
+++ b/election/Godeps/Godeps.json
@@ -1,5 +1,5 @@
 {
-	"ImportPath": "k8s.io/contrib/election",
+	"ImportPath": "github.com/tobad357/contrib/election",
 	"GoVersion": "go1.5",
 	"Packages": [
 		"./..."
@@ -16,8 +16,8 @@
 		},
 		{
 			"ImportPath": "github.com/blang/semver",
-			"Comment": "v3.1.0",
-			"Rev": "aea32c919a18e5ef4537bbd283ff29594b1b0165"
+			"Comment": "v3.0.1",
+			"Rev": "31b736133b98f26d5e078ec9eb591666edfd091f"
 		},
 		{
 			"ImportPath": "github.com/cpuguy83/go-md2man/md2man",
@@ -30,23 +30,23 @@
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/mount",
-			"Comment": "v1.4.1-4045-g2b27fe1",
-			"Rev": "2b27fe17a1b3fb8472fde96d768fa70996adf201"
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/pkg/parsers",
-			"Comment": "v1.4.1-4045-g2b27fe1",
-			"Rev": "2b27fe17a1b3fb8472fde96d768fa70996adf201"
+			"Comment": "v1.4.1-4831-g0f5c9d3",
+			"Rev": "0f5c9d301b9b1cca66b3ea0f9dec3b5317d3686d"
 		},
 		{
-			"ImportPath": "github.com/docker/docker/pkg/units",
-			"Comment": "v1.4.1-4045-g2b27fe1",
-			"Rev": "2b27fe17a1b3fb8472fde96d768fa70996adf201"
+			"ImportPath": "github.com/docker/go-units",
+			"Comment": "v0.1.0-21-g0bbddae",
+			"Rev": "0bbddae09c5a5419a8c6dcdd7ff90da3d450393b"
 		},
 		{
 			"ImportPath": "github.com/emicklei/go-restful",
-			"Comment": "v1.1.3-98-g1f9a0ee",
-			"Rev": "1f9a0ee00ff93717a275e15b30cf7df356255877"
+			"Comment": "v1.2",
+			"Rev": "777bb3f19bcafe2575ffb2a3e46af92509ae9594"
 		},
 		{
 			"ImportPath": "github.com/evanphx/json-patch",
@@ -54,7 +54,7 @@
 		},
 		{
 			"ImportPath": "github.com/fsouza/go-dockerclient",
-			"Rev": "175e1df973274f04e9b459a62cffc49808f1a649"
+			"Rev": "299d728486342c894e7fafd68e3a4b89623bef1d"
 		},
 		{
 			"ImportPath": "github.com/ghodss/yaml",
@@ -74,8 +74,8 @@
 		},
 		{
 			"ImportPath": "github.com/google/cadvisor/info/v1",
-			"Comment": "0.19.0",
-			"Rev": "0d6015c74114de9503d68c3c91efceee4dc41bd2"
+			"Comment": "v0.20.5",
+			"Rev": "9aa348ff5e191fcf3eccd59e5a434022aca77b87"
 		},
 		{
 			"ImportPath": "github.com/google/gofuzz",
@@ -100,18 +100,18 @@
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/cgroups",
-			"Comment": "v0.0.5",
-			"Rev": "97bc9a7faf3dd660d9be90a2880b2e37f3cdbf38"
+			"Comment": "v0.0.7",
+			"Rev": "7ca2aa4873aea7cb4265b1726acb24b90d8726c6"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/configs",
-			"Comment": "v0.0.5",
-			"Rev": "97bc9a7faf3dd660d9be90a2880b2e37f3cdbf38"
+			"Comment": "v0.0.7",
+			"Rev": "7ca2aa4873aea7cb4265b1726acb24b90d8726c6"
 		},
 		{
 			"ImportPath": "github.com/opencontainers/runc/libcontainer/system",
-			"Comment": "v0.0.5",
-			"Rev": "97bc9a7faf3dd660d9be90a2880b2e37f3cdbf38"
+			"Comment": "v0.0.7",
+			"Rev": "7ca2aa4873aea7cb4265b1726acb24b90d8726c6"
 		},
 		{
 			"ImportPath": "github.com/pborman/uuid",
@@ -150,11 +150,11 @@
 		},
 		{
 			"ImportPath": "github.com/spf13/cobra",
-			"Rev": "d732ab3a34e6e9e6b5bdac80707c2b6bad852936"
+			"Rev": "1c44ec8d3f1552cac48999f9306da23c4d8a288b"
 		},
 		{
 			"ImportPath": "github.com/spf13/pflag",
-			"Rev": "b084184666e02084b8ccb9b704bf0d79c466eb1d"
+			"Rev": "08b1a584251b5b62f458943640fc8ebd4d50aaa5"
 		},
 		{
 			"ImportPath": "github.com/ugorji/go/codec",
@@ -173,134 +173,164 @@
 			"Rev": "d466437aa4adc35830964cffc5b5f262c63ddcb4"
 		},
 		{
+			"ImportPath": "k8s.io/contrib/election/lib",
+			"Comment": "0.5.2-73-g362ee40",
+			"Rev": "362ee40a8ecb3f7403833b567dc3e067e0b8b428"
+		},
+		{
 			"ImportPath": "k8s.io/kubernetes/pkg/api",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apimachinery",
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/apis/authorization",
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/componentconfig",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/extensions",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/apis/metrics",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/auth/user",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/capabilities",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/clientset_generated/release_1_1",
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/leaderelection",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/metrics",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/record",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/transport",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/extensions/unversioned",
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
+		},
+		{
+			"ImportPath": "k8s.io/kubernetes/pkg/client/typed/generated/legacy/unversioned",
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/client/unversioned",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/conversion",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/credentialprovider",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/fieldpath",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/fields",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubectl",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/kubelet/qos",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/labels",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/runtime",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/types",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/util",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/version",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/pkg/watch",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/json",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/forked/reflect",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "k8s.io/kubernetes/third_party/golang/template",
-			"Comment": "v1.2.0-alpha.5-690-gab6edd8",
-			"Rev": "ab6edd8170522fa775fb5054d1c54b4e0d791444"
+			"Comment": "v1.2.0-alpha.7",
+			"Rev": "c0fd002fbb25d6a6cd8427d28b8ec78379c354a0"
 		},
 		{
 			"ImportPath": "speter.net/go/exp/math/dec/inf",

--- a/election/lib/election.go
+++ b/election/lib/election.go
@@ -106,6 +106,9 @@ func NewElection(electionId, id, namespace string, ttl time.Duration, callback f
 			}
 			callback(leader)
 		},
+		OnNewLeader: func(identity string) {
+			callback(leader)	
+		}
 	}
 
 	config := leaderelection.LeaderElectionConfig{

--- a/election/lib/election.go
+++ b/election/lib/election.go
@@ -107,8 +107,8 @@ func NewElection(electionId, id, namespace string, ttl time.Duration, callback f
 			callback(leader)
 		},
 		OnNewLeader: func(identity string) {
-			callback(leader)	
-		}
+			callback(identity)
+		},
 	}
 
 	config := leaderelection.LeaderElectionConfig{


### PR DESCRIPTION
This patch implements OnNewLeader support which was added recently to leaderelection
By doing this we prevent a current issue where a participator of the election doesn't get notified of a new leader unless they become the leader.
